### PR TITLE
add more map overrides

### DIFF
--- a/src/lib/buildingInfo.ts
+++ b/src/lib/buildingInfo.ts
@@ -174,4 +174,22 @@ export const mapLinkOverrides: {
     'https://locator.utdallas.edu/JO_2.702',
   'https://locator.utdallas.edu/VCB_1.201':
     'https://map.concept3d.com/?id=1772#!m/954137',
+  'https://locator.utdallas.edu/SCI_Atrium':
+    'https://map.concept3d.com/?id=1772#!ce/52360?ct/42147,52360?m/510259?s/Sciences%20Building',
+  'https://locator.utdallas.edu/SCI_Awning Area':
+    'https://map.concept3d.com/?id=1772#!ce/52360?ct/42147,52360?m/510259?s/Sciences%20Building',
+  'https://locator.utdallas.edu/SCI_Courtyard':
+    'https://map.concept3d.com/?id=1772#!ce/52360?ct/42147,52360?m/510259?s/Sciences%20Building',
+  'https://locator.utdallas.edu/ATC_2.908':
+    'https://map.concept3d.com/?id=1772#!ce/42138?m/530477?s/ATC%202.908',
+  'https://locator.utdallas.edu/ATC_3.805':
+    'https://map.concept3d.com/?id=1772#!ce/42138?m/541848?s/ATC%203.805',
+  'https://locator.utdallas.edu/FN_2.102':
+    'https://map.concept3d.com/?id=1772#!m/533592?s/FN%202.102',
+  'https://locator.utdallas.edu/SLC_1.206':
+    'https://map.concept3d.com/?id=1772#!ce/43194?m/1023820?s/SLC%201.206',
+  'https://locator.utdallas.edu/SPN_1.221':
+    'https://map.concept3d.com/?id=1772#!ce/43194?m/550498?s/SPN%201.221',
+  'https://locator.utdallas.edu/ATC_1.801A':
+    'https://map.concept3d.com/?id=1772#!ce/43194?m/541763?s/ATC%201.801',
 };


### PR DESCRIPTION
## Overview
Addresses issue #46 - adds override links to map (where before the link led to an error page).

## What Changed
Modified src/lib/buildingInfo.ts 

## Other Notes
Links were fixed for these rooms:
ATC 1.801A -> map doesn't have link for this room so I used link of a nearby room - ATC 1.801B 
ATC 2.908
ATC 3.805 -> comes up as ATC 3.805B but on map image it highlights 3.805
FN 2.102
SLC 1.206
SPN 1.221 -> comes up as SPN 1.220 but on map image it highlights 1.221
