### PR TITLE
Fix catching `mongo: no documents in result`

### DIFF
--- a/src/lib/fetchEvents.ts
+++ b/src/lib/fetchEvents.ts
@@ -7,7 +7,7 @@ export default async function fetchEvents<T>(
 ): Promise<GenericFetchedData<Hierarchy<T>>> {
   const API_KEY = process.env.REACT_APP_NEBULA_API_KEY;
   if (typeof API_KEY !== 'string') {
-    return { message: 'error', error: 'API key is undefined' };
+    return { message: 'error', data: 'API key is undefined' };
   }
 
   try {
@@ -24,10 +24,10 @@ export default async function fetchEvents<T>(
     const data = await res.json();
 
     if (data.message !== 'success') {
-      if (data.error === 'mongo: no documents in result') {
+      if (data.data === 'mongo: no documents in result') {
         return { message: 'success', data: {} };
       }
-      throw new Error(data.error ?? data.message);
+      throw new Error(data.data ?? data.message);
     }
 
     // Convert from array to object
@@ -43,7 +43,7 @@ export default async function fetchEvents<T>(
   } catch (error) {
     return {
       message: 'error',
-      error:
+      data:
         error instanceof Error ? error.message : 'An unknown error occurred',
     };
   }

--- a/src/lib/fetchRooms.ts
+++ b/src/lib/fetchRooms.ts
@@ -4,7 +4,7 @@ import type { Rooms } from '@/types/Rooms';
 export default async function fetchRooms(): Promise<GenericFetchedData<Rooms>> {
   const API_KEY = process.env.REACT_APP_NEBULA_API_KEY;
   if (typeof API_KEY !== 'string') {
-    return { message: 'error', error: 'API key is undefined' };
+    return { message: 'error', data: 'API key is undefined' };
   }
 
   try {
@@ -33,7 +33,7 @@ export default async function fetchRooms(): Promise<GenericFetchedData<Rooms>> {
   } catch (error) {
     return {
       message: 'error',
-      error:
+      data:
         error instanceof Error ? error.message : 'An unknown error occurred',
     };
   }

--- a/src/types/GenericFetchedData.ts
+++ b/src/types/GenericFetchedData.ts
@@ -1,6 +1,6 @@
 type GenericFetchedDataError = {
   message: 'error';
-  error?: string;
+  data?: string;
 };
 type GenericFetchedDataDone<T> = {
   message: 'success';


### PR DESCRIPTION
API schema changed from putting error messages in a field called error to a field called data.