### PR TITLE
Typo fix in TopMenu.tsx

### DIFF
--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -67,7 +67,7 @@ export default function TopMenu(props: Props) {
         />
         <Link
           href="/"
-          className="lext-lg md:text-xl font-display font-medium md:font-bold"
+          className="text-lg md:text-xl font-display font-medium md:font-bold"
         >
           UTD ROOMS
         </Link>


### PR DESCRIPTION
typo in classname

changed lext-lg to text-lg 

Slightly improves visibility