### PR TITLE
Adding constraints to table and popup styling

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -168,11 +168,6 @@
     border-radius: 0.75rem !important;
     overflow: hidden;
   }
-  .e-quick-popup-wrapper *,
-  .e-event-popup * {
-    word-break: break-word;
-    overflow-wrap: anywhere;
-  }
   .e-event-popup .e-subject {
     max-height: unset;
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -165,11 +165,8 @@
   /*Popup*/
   .e-quick-popup-wrapper,
   .e-event-popup {
-    width: 22rem !important;
-    max-width: min(22rem, calc(100vw - 1rem)) !important;
     border-radius: 0.75rem !important;
     overflow: hidden;
-    max-height: fit-content;
   }
   .e-quick-popup-wrapper *,
   .e-event-popup * {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -158,12 +158,7 @@
   }
 
   /*Allowing Overflow on table component*/
-  .e-schedule,
-  .e-schedule .e-table-container,
-  .e-schedule .e-content-wrap,
-  .e-schedule .e-content-wrap table,
-  .e-schedule .e-content-table,
-  .e-schedule .e-timeline-view {
+  .e-schedule {
     overflow: visible !important;
   }
 
@@ -174,6 +169,7 @@
     max-width: min(22rem, calc(100vw - 1rem)) !important;
     border-radius: 0.75rem !important;
     overflow: hidden;
+    max-height: fit-content;
   }
   .e-quick-popup-wrapper *,
   .e-event-popup * {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -156,9 +156,27 @@
   .e-appointment .e-appointment-details div:not(.e-indicator) div {
     display: block;
   }
+
+  /*Allowing Overflow on table component*/
+  .e-schedule,
+  .e-schedule .e-table-container,
+  .e-schedule .e-content-wrap,
+  .e-schedule .e-content-wrap table,
+  .e-schedule .e-content-table,
+  .e-schedule .e-timeline-view {
+    overflow: visible !important;
+  }
+
   /*Popup*/
-  .e-event-popup .e-subject {
-    max-height: unset;
+  .e-quick-popup-wrapper,
+  .e-event-popup {
+    width: 22rem !important;
+    max-width: min(22rem, calc(100vw - 1rem)) !important;
+  }
+  .e-quick-popup-wrapper *,
+  .e-event-popup * {
+    word-break: break-word;
+    overflow-wrap: anywhere;
   }
   .e-resource-icon::before {
     content: '\e756';

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -172,6 +172,8 @@
   .e-event-popup {
     width: 22rem !important;
     max-width: min(22rem, calc(100vw - 1rem)) !important;
+    border-radius: 0.75rem !important;
+    overflow: hidden;
   }
   .e-quick-popup-wrapper *,
   .e-event-popup * {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -180,6 +180,9 @@
     word-break: break-word;
     overflow-wrap: anywhere;
   }
+  .e-event-popup .e-subject {
+    max-height: unset;
+  }
   .e-resource-icon::before {
     content: '\e756';
   }


### PR DESCRIPTION
## Overview

Resolves #106 

Seems the issue lied with the way syncfusion handles its table component having overflow hidden as default forcing items its a parent of to be cut off. 

## What Changed

Added styling constraints to the schedule table overriding the overflow rule. Changed the popup sizing in order for it to stay a good size when it is overflowing from the table component. 

## Other Notes

Going to fix some small issues such as rounding not occurring on the top of popups. 