### PR TITLE
fix for buildingName  without ' ('

### DIFF
--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -604,7 +604,7 @@ export default function ResultsTable(props: Props) {
                 (buildingName &&
                   buildingName
                     .split(' (')[1]
-                    .toLowerCase()
+                    ?.toLowerCase()
                     .startsWith(search)) ||
                 events.some((event) =>
                   event.Subject.toLowerCase().startsWith(search),


### PR DESCRIPTION
## Overview

Fixes #130 by using an optional chaining operator
