### PR TITLE
in timeUtils.ts: use time instead of dayjs to snap time.

### DIFF
--- a/src/lib/timeUtils.ts
+++ b/src/lib/timeUtils.ts
@@ -1,4 +1,4 @@
-import dayjs, { type Dayjs } from 'dayjs';
+import { type Dayjs } from 'dayjs';
 
 export const defaultStartTime = 9;
 export const defaultEndTime = 22;
@@ -13,11 +13,11 @@ export function snapTime(time: Dayjs | null): Dayjs | null {
   if (time == null) {
     return null;
   }
-  if (time.isBefore(dayjs().hour(minTime).minute(0))) {
-    return dayjs().hour(minTime).minute(0);
+  if (time.isBefore(time.hour(minTime).minute(0))) {
+    return time.hour(minTime).minute(0);
   }
-  if (time.isAfter(dayjs().hour(maxTime).minute(0))) {
-    return dayjs().hour(maxTime).minute(0);
+  if (time.isAfter(time.hour(maxTime).minute(0))) {
+    return time.hour(maxTime).minute(0);
   }
   return time;
 }


### PR DESCRIPTION
## Overview

fixes #132 

## What Changed
Issue was `dayjs` would use today's day and overwrite the hour/min with the user-selected value.
Switched to using `time` (input to `snapTime()`)